### PR TITLE
add powershell version of pcd

### DIFF
--- a/pcd.ps1
+++ b/pcd.ps1
@@ -1,0 +1,44 @@
+$env:PCD_CONFIG = "$env:UserProfile\.pcd"
+
+Function usage {
+  echo "[add PATH | edit]"
+  exit
+}
+Function edit {
+  if ("$env:EDITOR" -ne "") {
+    & "$env:EDITOR" "$env:PCD_CONFIG"
+    exit
+  } else {
+    & notepad "$env:PCD_CONFIG"
+    exit
+  }
+}
+Function query {
+# If you have a problem caused by character-set, modify below part like:
+# ... | iconv -f char -t utf-8 ^| peco --null'
+  ForEach ($line in $($(type "$env:PCD_CONFIG" | peco) -split "`r`n")) {
+    cd $line
+    break
+  }
+}
+
+if ($args[0] -eq "add") {
+  if ($args[1]) {
+    usage
+  } else {
+    $(get-location).Path >> "$env:PCD_CONFIG"
+    exit
+  }
+}
+if ($args[0] -eq "edit") {
+  if ($args[1]) {
+    usage
+  } else {
+    edit
+  }
+}
+if ($args[0]) {
+  usage
+} else {
+  query
+}


### PR DESCRIPTION
There are not many frecency dir switcher for Powershell. In particular [Zlocation](https://github.com/vors/ZLocation) breaks PoSh Git prompt (despite following the instructions). Therefore a simple alternative for Windows Powershell and Cmd is still useful. Replace `peco` by any other fuzzy finder, say `fzf`,  by preference.